### PR TITLE
Added: ranged text page extraction from a PDF file.

### DIFF
--- a/src/pdfcreator/PDFTextExtract.java
+++ b/src/pdfcreator/PDFTextExtract.java
@@ -10,6 +10,11 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.lang.NullPointerException;
+import java.util.stream.IntStream;
+import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  *
@@ -17,44 +22,96 @@ import java.io.PrintWriter;
  */
 public class PDFTextExtract {
     public PDFTextExtract() {}
-    
+
     public String[] extract(String filename) throws IOException {
         PdfReader reader = new PdfReader(filename);
-        int pages = reader.getNumberOfPages();
-        
-        String[] result = new String[pages];
-        
-        for (int i = 0 ; i < pages ; i++) {
-            String text = PdfTextExtractor.getTextFromPage(reader, i + 1);
-           
-            result[i] = text;
+	int pages = reader.getNumberOfPages();
+
+	String[] result = new String[pages];
+
+	for (int i = 0 ; i < pages ; i++) {
+	    String text = PdfTextExtractor.getTextFromPage(reader, i + 1);
+	    result[i] = text;
         }
-        
+
         return result;
     }
-    
+
+    public String[] extract(String filename, int start, int end) throws IOException, NullPointerException {
+	PdfReader reader = new PdfReader(filename);
+        
+	List<Integer> pageNrs = IntStream.rangeClosed(start, end)
+	    .boxed()
+	    .collect(Collectors.toList());
+      
+	String[] result = new String[pageNrs.size()]; 
+
+	int i = 0;
+	for (int pageNr : pageNrs) {
+	    result[i] = PdfTextExtractor.getTextFromPage(reader, pageNr);
+	    i++;
+	}
+
+	return result;
+    }
+
     public static void main(String[] args) throws Exception {
-        if (args.length != 2) {
+        if (args.length < 2) {
             System.err.println("usage: PDFTextExtract file out");
             System.exit(1);
         }
         
         String filename = args[0];
         String output = args[1];
-        
+        String range = (args.length == 3) ? args[2] : "";
+         
+	int start = 0;
+	int end = 0;
+
         if (! (new File(output)).isDirectory()) {
             System.err.println("output " + output + " isn't a directory");
+	    System.exit(1);
         }
-        
-        PDFTextExtract tool = new PDFTextExtract();
-        String[] pages = tool.extract(filename);
-        
-        for (int i = 0 ; i < pages.length ; i++) {
-            String out_file = output + "/page_" + (i+1) + ".txt";
-            System.out.println("creating file " + out_file);
+
+	String [] pages = new String[0];
+	if (! (range.isEmpty()) ) {
+	    if (! range.matches("^[0-9]*\\.\\.[0-9]*")) {
+	        System.err.println("Range doesn't match expected format n..m");
+		System.exit(1);
+	    }
+	    
+	    List<Integer> bounds = Arrays.stream(range.split("\\.\\."))
+		.map(Integer::parseInt)
+		.collect(Collectors.toList());
+
+	    start = bounds.get(0);
+	    end = bounds.get(1);
+
+	    if (start >= end) {
+		System.err.println("The start page can't be greater or equal then the end page.");
+		System.exit(1);
+	    }
+
+	    PDFTextExtract tool = new PDFTextExtract();
+	    try {
+	        pages = tool.extract(filename, start, end);
+	    } catch (IOException | NullPointerException e) {
+		System.err.println("Something went wrong. Likely, the provided range exceeded the range of available pages.");
+		System.exit(1);
+	    }
+		
+	} else {
+	    PDFTextExtract tool = new PDFTextExtract();
+	    pages = tool.extract(filename);
+	} 
+
+	for (int i = 0 ; i < pages.length ; i++) {
+	    int pageNr = (start > 0) ? start + i : i + 1;
+	    String out_file = output + "/page_" + pageNr + ".txt";
+	    System.out.println("creating file " + out_file);
             PrintWriter out = new PrintWriter(out_file);
-            out.print(pages[i]);
-            out.close();
+	    out.print(pages[i]);
+	    out.close();
         }
     }
 }


### PR DESCRIPTION
## Context

Executing the `pdfextract` command will result in a directory filled with discrete TXT files which represent all pages in the source PDF file. However, it is not possible to do a "ranged" extraction, that is: extract a slice from the PDF file (i.e. pages 5 to 10).  This PR adds this functionality.

## How this works

__valid command__
`$ pdfextract file.pdf /tmp/foobar 5..10 # extract pages 5 to 10 as TXT files in /tmp/foobar`

__these will yield an error message__
`$ pdfextract file.pdf /tmp/foobar 5**10 # format of the range is n..m with n and m being integers`
`$ pdfextract file.pdf /tmp/foobar 10..5 # lower bound can't be larger or equal then upper bound`
`$ pdfextract file.pdf /tmp/foobar 5000..10000 # fails because the bounds are higher then the cardinality of the pages in the PDF` 

## Further enhancements

* This doesn't include extraction of a single page from the PDF (minimum is 2 pages)
* This doesn't include extraction of image files (png files) from a PDF via `pdfimages` 
